### PR TITLE
Fix composer call in the project bootstrap part

### DIFF
--- a/src/fr/2_installation_configuration/2_bootstraped_project.md
+++ b/src/fr/2_installation_configuration/2_bootstraped_project.md
@@ -8,7 +8,7 @@ Vous aurez aussi besoin d'une base de données SQL pour stocker la configuration
 Pour commencer, il vous rajouter les bundles synapse :
 
 ```bash
-./bin/composer require synapse-cmf/synapse-cmf ~1.0@dev
+composer require synapse-cmf/synapse-cmf ~1.0@dev
 ```
 
 Puis les inclures dans votre application (comment n'importe quel autre bundle) :


### PR DESCRIPTION
Hello,

Most people are using composer as global tool of the computer. I get that some of them are using `php composer.phar`... But I never see `./bin/composer` !

I guess this is a typo :) .
